### PR TITLE
fix: too many constructor params for HsExpr.MG

### DIFF
--- a/src/Info.hs
+++ b/src/Info.hs
@@ -131,7 +131,7 @@ getSrcSpan _ = Nothing
 
 getTypeLHsBind :: GHC.TypecheckedModule -> GHC.LHsBind GHC.Id -> GHC.Ghc (Maybe (GHC.SrcSpan, GHC.Type))
 #if __GLASGOW_HASKELL__ >= 708
-getTypeLHsBind _ (GHC.L spn GHC.FunBind{GHC.fun_matches = HsExpr.MG _ _ typ}) = return $ Just (spn, typ)
+getTypeLHsBind _ (GHC.L spn GHC.FunBind{GHC.fun_matches = grp}) = return $ Just (spn, HsExpr.mg_res_ty grp)
 #else
 getTypeLHsBind _ (GHC.L spn GHC.FunBind{GHC.fun_matches = GHC.MatchGroup _ typ}) = return $ Just (spn, typ)
 #endif


### PR DESCRIPTION
Building against ghc-7.8.2 on OSX, I got a compile error:

```
[ 2 of 11] Compiling Info             ( src/Info.hs, dist/build/hdevtools/hdevtools-tmp/Info.o )

src/Info.hs:134:59:
    Constructor ‘GHC.MG’ should have 3 arguments, but has been given 4
    In the pattern: GHC.MG _ _ typ _
    In the pattern: GHC.FunBind {GHC.fun_matches = GHC.MG _ _ typ _}
    In the pattern:
      GHC.L spn (GHC.FunBind {GHC.fun_matches = GHC.MG _ _ typ _})
```

According to [the documentation for `HsExpr.MatchGroup` in ghc-7.8.2](https://www.haskell.org/ghc/docs/7.8.2/html/libraries/ghc-7.8.2/HsExpr.html#t:MatchGroup) `MG` only takes 3
parameters:

``` haskell
data MatchGroup id body
  = MG { mg_alts    :: [LMatch id body]  -- The alternatives
       , mg_arg_tys :: [PostTcType]      -- Types of the arguments, t1..tn
       , mg_res_ty  :: PostTcType  }     -- Type of the result, tr
     -- The type is the type of the entire group
     --      t1 -> ... -> tn -> tr
     -- where there are n patterns
  deriving (Data, Typeable)
```

So I fixed the bug by removing the extra ignored parameter, and now it
compiles fine.
