### PR TITLE
Add --path option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ background process, not your current directory. This can cause problems, and
 therefore it is recommended that you leave the socket file as the default, and
 always run `hdevtools` from the same directory.
 
+You can specify the path to a target file with the `--path` option. This is 
+useful for integration with IDEs that submit a *copy* of the original source
+file (in a temporary directory) to `hdevtools` making it impossible to extract
+the `.cabal` information for the file's project. In such cases, you can run as:
+
+    $ hdevtools check -p /path/to/file.hs /tmp/file.hs
+
+and `hdevtools` will use the given path to obtain the `.cabal` information.
+
+
 ### Specifying GHC Options ###
 
 For most non-trivial projects, you will need to tell `hdevtools` about

--- a/src/CommandArgs.hs
+++ b/src/CommandArgs.hs
@@ -44,34 +44,37 @@ fullVersion =
 
 data HDevTools
     = Admin
-        { socket :: Maybe FilePath
+        { socket       :: Maybe FilePath
         , start_server :: Bool
-        , noDaemon :: Bool
-        , status :: Bool
-        , stop_server :: Bool
+        , noDaemon     :: Bool
+        , status       :: Bool
+        , stop_server  :: Bool
         }
     | Check
-        { socket :: Maybe FilePath
+        { socket  :: Maybe FilePath
         , ghcOpts :: [String]
-        , file :: String
+        , path    :: Maybe String
+        , file    :: String
         }
     | ModuleFile
-        { socket :: Maybe FilePath
+        { socket  :: Maybe FilePath
         , ghcOpts :: [String]
         , module_ :: String
         }
     | Info
-        { socket :: Maybe FilePath
-        , ghcOpts :: [String]
-        , file :: String
+        { socket     :: Maybe FilePath
+        , ghcOpts    :: [String]
+        , path       :: Maybe String
+        , file       :: String
         , identifier :: String
         }
     | Type
-        { socket :: Maybe FilePath
+        { socket  :: Maybe FilePath
         , ghcOpts :: [String]
-        , file :: String
-        , line :: Int
-        , col :: Int
+        , path    :: Maybe String
+        , file    :: String
+        , line    :: Int
+        , col     :: Int
         }
     deriving (Show, Data, Typeable)
 
@@ -86,48 +89,52 @@ dummyAdmin = Admin
 
 dummyCheck :: HDevTools
 dummyCheck = Check
-    { socket = Nothing
+    { socket  = Nothing
     , ghcOpts = []
-    , file = ""
+    , path    = Nothing
+    , file    = ""
     }
 
 dummyModuleFile :: HDevTools
 dummyModuleFile = ModuleFile
-    { socket = Nothing
+    { socket  = Nothing
     , ghcOpts = []
     , module_ = ""
     }
 
 dummyInfo :: HDevTools
 dummyInfo = Info
-    { socket = Nothing
-    , ghcOpts = []
-    , file = ""
+    { socket     = Nothing
+    , ghcOpts    = []
+    , path       = Nothing
+    , file       = ""
     , identifier = ""
     }
 
 dummyType :: HDevTools
 dummyType = Type
-    { socket = Nothing
+    { socket  = Nothing
     , ghcOpts = []
-    , file = ""
-    , line = 0
-    , col = 0
+    , path    = Nothing
+    , file    = ""
+    , line    = 0
+    , col     = 0
     }
 
 admin :: Annotate Ann
 admin = record dummyAdmin
-    [ socket   := def += typFile += help "socket file to use"
-    , start_server   := def            += help "start server"
-    , noDaemon := def            += help "do not daemonize (only if --start-server)"
-    , status   := def            += help "show status of server"
-    , stop_server := def         += help "shutdown the server"
+    [ socket       := def += typFile += help "socket file to use"
+    , start_server := def            += help "start server"
+    , noDaemon     := def            += help "do not daemonize (only if --start-server)"
+    , status       := def            += help "show status of server"
+    , stop_server  := def            += help "shutdown the server"
     ] += help "Interactions with the server"
 
 check :: Annotate Ann
 check = record dummyCheck
-    [ socket   := def += typFile += help "socket file to use"
-    , ghcOpts  := def += typ "OPTION"   += help "ghc options"
+    [ socket   := def += typFile      += help "socket file to use"
+    , ghcOpts  := def += typ "OPTION" += help "ghc options"
+    , path     := def += typFile      += help "path to target file"
     , file     := def += typFile      += argPos 0 += opt ""
     ] += help "Check a haskell source file for errors and warnings"
 
@@ -140,8 +147,9 @@ moduleFile = record dummyModuleFile
 
 info :: Annotate Ann
 info = record dummyInfo
-    [ socket     := def += typFile += help "socket file to use"
+    [ socket     := def += typFile      += help "socket file to use"
     , ghcOpts    := def += typ "OPTION" += help "ghc options"
+    , path       := def += typFile      += help "path to target file"
     , file       := def += typFile      += argPos 0 += opt ""
     , identifier := def += typ "IDENTIFIER" += argPos 1
     ] += help "Get info from GHC about the specified identifier"
@@ -150,6 +158,7 @@ type_ :: Annotate Ann
 type_ = record dummyType
     [ socket   := def += typFile += help "socket file to use"
     , ghcOpts  := def += typ "OPTION" += help "ghc options"
+    , path     := def += typFile      += help "path to target file"
     , file     := def += typFile      += argPos 0 += opt ""
     , line     := def += typ "LINE"   += argPos 1
     , col      := def += typ "COLUMN" += argPos 2

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import Data.Maybe (fromMaybe)
-import Data.Traversable (Traversable(..))
+-- import Data.Traversable (Traversable(..))
 import System.Directory (getCurrentDirectory)
 import System.Environment (getProgName)
 import System.IO (hPutStrLn, stderr)
@@ -15,9 +15,9 @@ import Server (startServer, createListenSocket)
 import Types (Command(..), CommandExtra(..), emptyCommandExtra)
 
 absoluteFilePath :: FilePath -> IO FilePath
-absoluteFilePath path = if isAbsolute path then return path else do
+absoluteFilePath p = if isAbsolute p then return p else do
     dir <- getCurrentDirectory
-    return $ dir </> path
+    return $ dir </> p
 
 
 defaultSocketFile :: FilePath
@@ -31,11 +31,22 @@ fileArg args@(Check {}) = Just $ file args
 fileArg args@(Info  {}) = Just $ file args
 fileArg args@(Type  {}) = Just $ file args
 
+pathArg' :: HDevTools -> Maybe String
+pathArg' (Admin {})      = Nothing
+pathArg' (ModuleFile {}) = Nothing
+pathArg' args@(Check {}) = path args
+pathArg' args@(Info  {}) = path args
+pathArg' args@(Type  {}) = path args
+
+pathArg :: HDevTools -> Maybe String
+pathArg args = case path args of
+                Just x  -> Just x
+                Nothing -> fileArg args
 
 main :: IO ()
 main = do
     args <- loadHDevTools
-    dir  <- maybe getCurrentDirectory (return . takeDirectory) $ fileArg args
+    dir  <- maybe getCurrentDirectory (return . takeDirectory) $ pathArg args
     mCabalFile <- findCabalFile dir >>= traverse absoluteFilePath
     let extra = emptyCommandExtra
                     { ceGhcOptions = ghcOpts args


### PR DESCRIPTION
Hi, I added a `--path` option to specify paths to the target file. This sounds superfluous but is handy for those editors/IDEs (e.g. Atom) which run `hdevtools` on a *copy* of the file created in some random temporary directory where the context information (e.g. cabal information) is unavailable.

I've explained the use-case in the README, and the main change is:

+ `src/CommandArgs`: the addition of a `path` field to the `HDevTools` type 
+ `src/Main.hs`: using the `path` to find the cabalDirectory (instead of just the `file`).

Thanks!

Ranjit.