### PR TITLE
Update README and bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ syntax checker for Emacs, and there is a [flycheck-hdevtools][6] checker availab
 
 ### Atom - [linter][8] ###
 
-There is a [linter-hdevtools][8] package for using `hdevtools` to quickly
-find type errors in Haskell files in the the [Atom][7] editor.
+There are *two* packages for the [Atom](https://atom.io) editor:
+
++ [linter-hdevtools][8] quickly finds and underlines type errors in Haskell files,
++ [hover-tooltips-hdevtools][9] displays the types of identifiers under the mouse. 
 
 ### Manual Editor Integration for any Editor ###
 
@@ -200,3 +202,5 @@ client-server architecture it is much faster.
 [6]: https://github.com/flycheck/flycheck-hdevtools
 [7]: https://atom.io
 [8]: https://atom.io/packages/linter-hdevtools
+[9]: https://atom.io/packages/hover-tooltips-hdevtools
+

--- a/src/Client.hs
+++ b/src/Client.hs
@@ -18,7 +18,8 @@ import Util (readMaybe)
 
 connect :: FilePath -> IO Handle
 connect sock = do
-    connectTo "" (UnixSocket sock)
+  r <- connectTo "" (UnixSocket sock)
+  return r
 
 getServerStatus :: FilePath -> IO ()
 getServerStatus sock = do

--- a/src/Client.hs
+++ b/src/Client.hs
@@ -18,8 +18,7 @@ import Util (readMaybe)
 
 connect :: FilePath -> IO Handle
 connect sock = do
-  r <- connectTo "" (UnixSocket sock)
-  return r
+  connectTo "" (UnixSocket sock)
 
 getServerStatus :: FilePath -> IO ()
 getServerStatus sock = do

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -39,7 +39,7 @@ pathArg' args@(Info  {}) = path args
 pathArg' args@(Type  {}) = path args
 
 pathArg :: HDevTools -> Maybe String
-pathArg args = case path args of
+pathArg args = case pathArg' args of
                 Just x  -> Just x
                 Nothing -> fileArg args
 


### PR DESCRIPTION
There are two things in this PR:

1. I created a new atom package for hover-tooltips using hdevtools so just linked to it,
2. The earlier PR had a rather silly bug in `pathArg` (it was calling the record selector `path` even in cases when it didn't exist!). That is now fixed. (Apologies for the bug in the first case!)
