### PR TITLE
First cut at support for `stack`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .cabal-sandbox
 cabal.sandbox.config
 *.sw[a-z]
+.stack-work/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ hdevtools
 
 Persistent GHC powered background server for FAST Haskell development tools
 
+
 About
 -----
 

--- a/hdevtools.cabal
+++ b/hdevtools.cabal
@@ -68,7 +68,7 @@ executable hdevtools
                        ghc-paths,
                        syb,
                        network,
-                       process,
+                       process >= 1.2.3.0,
                        time,
                        unix
 

--- a/hdevtools.cabal
+++ b/hdevtools.cabal
@@ -55,6 +55,7 @@ executable hdevtools
                        Info,
                        Main,
                        Server,
+                       Stack,
                        Types,
                        Util,
                        Paths_hdevtools
@@ -67,6 +68,7 @@ executable hdevtools
                        ghc-paths,
                        syb,
                        network,
+                       process,
                        time,
                        unix
 

--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -162,9 +162,6 @@ getPackageGhcOpts path mbStack = do
                                        , ghcOptPackages = overNubListR (filter (\(_, pkgId, _) -> Just (pkgName pkgId) /= mbLibName)) $ (ghcOptPackages ghcOpts')
                                        , ghcOptSourcePath = overNubListR (map (baseDir </>)) (ghcOptSourcePath ghcOpts')
                                        }
-                debug $ "STACKINFO: "      ++ show mbStack
-                debug $ "CONFIGFLAGS: "    ++ show cfgFlags
-                debug $ "LOCALBUILDINFO: " ++ show localBuildInfo
                 putStrLn "configuring"
                 (ghcInfo,_,_) <- GHC.configure silent Nothing Nothing defaultProgramConfiguration
 

--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -41,23 +41,6 @@ import System.Directory (doesFileExist, getDirectoryContents)
 import System.FilePath (takeDirectory, splitFileName, (</>))
 
 
-{-
-
-, ghcOptHiDir = Flag "/Users/rjhala/research/stack/liquid/liquidhaskell/dist/build"
-, ghcOptObjDir = Flag "/Users/rjhala/research/stack/liquid/liquidhaskell/dist/build"
-, ghcOptOutputDir = Flag "/Users/rjhala/research/stack/liquid/liquidhaskell/dist/build"
-, ghcOptStubDir = Flag "/Users/rjhala/research/stack/liquid/liquidhaskell/dist/build",
-, ghcOptCppIncludePath = ["/Users/rjhala/research/stack/liquid/liquidhaskell/dist/build/autogen"
-                         ,"/Users/rjhala/research/stack/liquid/liquidhaskell/dist/build"]
-, ghcOptCppIncludes = ["/Users/rjhala/research/stack/liquid/liquidhaskell/dist/build/autogen/cabal_macros.h"]
-, ghcOptSourcePath = ["/Users/rjhala/research/stack/liquid/liquidhaskell/src"
-                     ,"/Users/rjhala/research/stack/liquid/liquidhaskell/include"
-                     ,"/Users/rjhala/research/stack/liquid/liquidhaskell/dist/build"
-                     ,"/Users/rjhala/research/stack/liquid/liquidhaskell/."
-                     ,"/Users/rjhala/research/stack/liquid/liquidhaskell/dist/build/autogen"],
-
--}
-
 componentName :: Component -> ComponentName
 componentName =
     foldComponent (const CLibName)

--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -96,10 +96,10 @@ allComponentsBy pkg_descr f =
 #endif
 
 
-getPackageGhcOpts :: FilePath -> IO (Either String [String])
-getPackageGhcOpts path = do
+getPackageGhcOpts :: FilePath -> [FilePath] -> IO (Either String [String])
+getPackageGhcOpts path dbs = do
     getPackageGhcOpts' `catch` (\e -> do
-        return $ Left $ "Cabal error: " ++ (ioeGetErrorString (e :: IOException)))
+        return $ Left $ "Cabalasdasd error: " ++ (ioeGetErrorString (e :: IOException)))
   where
     getPackageGhcOpts' :: IO (Either String [String])
     getPackageGhcOpts' = do
@@ -109,6 +109,7 @@ getPackageGhcOpts path = do
                             { configDistPref = toFlag $ takeDirectory path </> "dist"
                             -- TODO: figure out how to find out this flag
                             , configUserInstall = toFlag True
+                            , configPackageDBs  = Just . SpecificPackageDB <$> dbs
                             }
 
         let sandboxConfig = takeDirectory path </> "cabal.sandbox.config"

--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -137,7 +137,6 @@ configSession state clientSend config = do
                       Just cabalConfig -> do
                           liftIO $ setCurrentDirectory . takeDirectory $ cabalConfigPath cabalConfig
                           liftIO $ getPackageGhcOpts (cabalConfigPath cabalConfig) (configStack config)
-    liftIO $ debug $ "CABALGHCOPTS: " ++ show eCabalGhcOpts
     case eCabalGhcOpts of
       Left e -> return $ Left e
       Right cabalGhcOpts -> do
@@ -147,6 +146,7 @@ configSession state clientSend config = do
   where
     updateDynFlags :: [String] -> GHC.Ghc ()
     updateDynFlags ghcOpts = do
+        liftIO $ debug $ "GHCOPTS: " ++ show ghcOpts
         initialDynFlags <- GHC.getSessionDynFlags
         let updatedDynFlags = initialDynFlags
                 { GHC.log_action    = logAction state clientSend

--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -146,7 +146,6 @@ configSession state clientSend config = do
   where
     updateDynFlags :: [String] -> GHC.Ghc ()
     updateDynFlags ghcOpts = do
-        liftIO $ debug $ "GHCOPTS: " ++ show ghcOpts
         initialDynFlags <- GHC.getSessionDynFlags
         let updatedDynFlags = initialDynFlags
                 { GHC.log_action    = logAction state clientSend

--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -65,7 +65,7 @@ newConfig cmdExtra = do
     mbCabalConfig <- traverse mkCabalConfig $ ceCabalConfig cmdExtra
     mbStackConfig <- getStackConfig cmdExtra
 
-    return $ Config { configGhcOpts = ceGhcOptions cmdExtra
+    return $ Config { configGhcOpts = "-O0" : ceGhcOptions cmdExtra
                     , configCabal = mbCabalConfig
                     , configStack = mbStackConfig
                     }

--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -20,7 +20,6 @@ import qualified Exception (ExceptionMonad)
 import qualified GHC
 import qualified GHC.Paths
 import qualified Outputable
--- RJ import qualified DynFlags
 import System.Posix.Types (EpochTime)
 import System.Posix.Files (getFileStatus, modificationTime)
 
@@ -138,7 +137,7 @@ configSession state clientSend config = do
                       Just cabalConfig -> do
                           liftIO $ setCurrentDirectory . takeDirectory $ cabalConfigPath cabalConfig
                           liftIO $ getPackageGhcOpts (cabalConfigPath cabalConfig) (configStack config)
-    liftIO $ debug $ "eStackGhcDbs:" ++ show eCabalGhcOpts
+    liftIO $ debug $ "CABALGHCOPTS: " ++ show eCabalGhcOpts
     case eCabalGhcOpts of
       Left e -> return $ Left e
       Right cabalGhcOpts -> do
@@ -153,7 +152,6 @@ configSession state clientSend config = do
                 { GHC.log_action    = logAction state clientSend
                 , GHC.ghcLink       = GHC.NoLink
                 , GHC.hscTarget     = GHC.HscInterpreted
-                --  RJ , GHC.extraPkgConfs = ((DynFlags.PkgConfFile <$> eStackGhcDbs) ++)
                 }
         (finalDynFlags, _, _) <- GHC.parseDynamicFlags updatedDynFlags (map GHC.noLoc ghcOpts)
         _ <- GHC.setSessionDynFlags finalDynFlags
@@ -161,9 +159,6 @@ configSession state clientSend config = do
 
     handleGhcError :: GHC.GhcException -> GHC.Ghc String
     handleGhcError e = return $ GHC.showGhcException e ""
-
-    -- RJ eStackGhcDbs :: [FilePath]
-    -- RJ eStackGhcDbs = maybe [] stackDbs (configStack config)
 
 runCommand :: IORef State -> ClientSend -> Command -> GHC.Ghc ()
 runCommand _ clientSend (CmdCheck file) = do

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,7 +1,12 @@
+{-# LANGUAGE CPP #-}
+
 module Main where
 
+#if __GLASGOW_HASKELL__ < 709
+import Data.Traversable (traverse)
+#endif
+
 import Data.Maybe (fromMaybe)
--- import Data.Traversable (Traversable(..))
 import System.Directory (getCurrentDirectory)
 import System.Environment (getProgName)
 import System.IO (hPutStrLn, stderr)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -46,16 +46,16 @@ pathArg args = case pathArg' args of
 main :: IO ()
 main = do
     args <- loadHDevTools
-    dir  <- maybe getCurrentDirectory (return . takeDirectory) $ pathArg args
+    let argPath = pathArg args
+    dir  <- maybe getCurrentDirectory (return . takeDirectory) argPath
     mCabalFile <- findCabalFile dir >>= traverse absoluteFilePath
     let extra = emptyCommandExtra
-                    { ceGhcOptions = ghcOpts args
+                    { ceGhcOptions  = ghcOpts args
                     , ceCabalConfig = mCabalFile
+                    , cePath        = argPath
                     }
-
     let defaultSocketPath = maybe "" takeDirectory mCabalFile </> defaultSocketFile
     let sock = fromMaybe defaultSocketPath $ socket args
-
     case args of
         Admin {} -> doAdmin sock args extra
         Check {} -> doCheck sock args extra

--- a/src/Stack.hs
+++ b/src/Stack.hs
@@ -1,4 +1,4 @@
-module Stack (getStackDbs) where
+module Stack (debug, getStackDbs) where
 
 import Data.Char (isSpace)
 import System.Process
@@ -10,8 +10,19 @@ import Types
 -- 1. Figure out if this is a stack project,
 -- 2. Run stack exec ... to extract path
 
+debug :: String -> IO ()
+debug msg = appendFile "/Users/rjhala/tmp/hdevtools-debug" $ msg ++ "\n"
+
 getStackDbs :: CommandExtra -> IO (Maybe [FilePath])
-getStackDbs ce = case cePath ce of
+getStackDbs ce = do
+  r <- getStackDbs_ ce
+  debug $ "CommandExtra: " ++ show ce
+  debug $ "Result: " ++ show r
+  return r
+
+
+getStackDbs_ :: CommandExtra -> IO (Maybe [FilePath])
+getStackDbs_ ce = case cePath ce of
                    Nothing -> return Nothing
                    Just p  -> getStackDbs' p
 

--- a/src/Stack.hs
+++ b/src/Stack.hs
@@ -13,17 +13,21 @@ import Types
 getStackDbs :: CommandExtra -> IO (Maybe [FilePath])
 getStackDbs ce = case cePath ce of
                    Nothing -> return Nothing
-                   Just p  -> do b <- isStackProject p
-                                 if b
-                                   then Just <$> pathStackDbs p
-                                   else return Nothing
+                   Just p  -> getStackDbs' p
+
+getStackDbs' :: FilePath -> IO (Maybe [FilePath])
+getStackDbs' p = do
+  b <- isStackProject p
+  if b
+    then Just <$> pathStackDbs p
+    else return Nothing
 
 isStackProject :: FilePath -> IO Bool
 isStackProject p = existsM doesFileExist paths
   where
     paths        = [ d </> "stack.yaml" | d <- pathsToRoot dir]
     dir          = takeDirectory p
-    
+
 pathsToRoot :: FilePath -> [FilePath]
 pathsToRoot p
   | p == parent = [p]

--- a/src/Stack.hs
+++ b/src/Stack.hs
@@ -7,6 +7,7 @@ module Stack
 
 import Data.Maybe (listToMaybe)
 import Data.Char (isSpace)
+import Control.Applicative((<$>), (<*>))
 import System.Process
 import System.FilePath
 import System.Directory

--- a/src/Stack.hs
+++ b/src/Stack.hs
@@ -3,8 +3,6 @@ module Stack
         StackConfig (..)
         -- * Run `stack exec` to compute @StackConfig@
       , getStackConfig
-        -- * Temporary logger
-      , debug
       ) where
 
 import Data.Maybe (listToMaybe)
@@ -100,7 +98,3 @@ execInPath :: String -> FilePath -> IO String
 execInPath cmd p = readCreateProcess prc ""
   where
     prc          = (shell cmd) { cwd = Just $ takeDirectory p }
-
-
-debug :: String -> IO ()
-debug msg = appendFile "~/tmp/hdevtools-debug" $ msg ++ "\n"

--- a/src/Stack.hs
+++ b/src/Stack.hs
@@ -16,19 +16,16 @@ import Control.Monad (filterM)
 import Types
 
 -- | This module adds support for `stack`, as follows:
---   1. Figure out if this is a stack project,
+--   1. Figure out if the target-file is in a stack project,
 --   2. Run `stack exec` to extract `StackConfig`
 --   3. The `StackConfig` is used to suitably alter the cabal ConfigFlags in Cabal.hs
 
-debug :: String -> IO ()
-debug msg = appendFile "/Users/rjhala/tmp/hdevtools-debug" $ msg ++ "\n"
 
 -- TODO: Move into Types?
 data StackConfig = StackConfig { stackDist :: FilePath
                                , stackDbs  :: [FilePath]
                                }
                    deriving (Eq, Show)
-
 
 --------------------------------------------------------------------------------
 getStackConfig :: CommandExtra -> IO (Maybe StackConfig)
@@ -61,9 +58,6 @@ pathsToRoot p
   where
     parent      = takeDirectory p
 
--- existsM :: (Monad m) => (a -> m Bool) -> [a] -> m Bool
--- existsM f xs = (not . null) <$> filterM f xs
-
 --------------------------------------------------------------------------------
 getStackDist :: FilePath -> IO FilePath
 --------------------------------------------------------------------------------
@@ -72,11 +66,6 @@ getStackDist p = trim <$> execInPath cmd p
     cmd        = "stack path --dist-dir"
     -- dir        = takeDirectory p
     -- splice     = (dir </>) . trim
-
--- extractPath dist' = do
---   let dist = trim dist'
---   b <- doesDirectoryExist dist
---   return $ if b then Just dist else Nothing
 
 --------------------------------------------------------------------------------
 getStackDbs :: FilePath -> IO [FilePath]
@@ -111,3 +100,7 @@ execInPath :: String -> FilePath -> IO String
 execInPath cmd p = readCreateProcess prc ""
   where
     prc          = (shell cmd) { cwd = Just $ takeDirectory p }
+
+
+debug :: String -> IO ()
+debug msg = appendFile "~/tmp/hdevtools-debug" $ msg ++ "\n"

--- a/src/Stack.hs
+++ b/src/Stack.hs
@@ -1,0 +1,59 @@
+module Stack (getStackDbs) where
+
+import Data.Char (isSpace)
+import System.Process
+import System.FilePath
+import System.Directory
+import Control.Monad (filterM)
+import Types
+
+-- 1. Figure out if this is a stack project,
+-- 2. Run stack exec ... to extract path
+
+getStackDbs :: CommandExtra -> IO (Maybe [FilePath])
+getStackDbs ce = case cePath ce of
+                   Nothing -> return Nothing
+                   Just p  -> do b <- isStackProject p
+                                 if b
+                                   then Just <$> pathStackDbs p
+                                   else return Nothing
+
+isStackProject :: FilePath -> IO Bool
+isStackProject p = existsM doesFileExist paths
+  where
+    paths        = [ d </> "stack.yaml" | d <- pathsToRoot dir]
+    dir          = takeDirectory p
+    
+pathsToRoot :: FilePath -> [FilePath]
+pathsToRoot p
+  | p == parent = [p]
+  | otherwise   = p : pathsToRoot parent
+  where
+    parent      = takeDirectory p
+
+existsM :: (Monad m) => (a -> m Bool) -> [a] -> m Bool
+existsM f xs = (not . null) <$> filterM f xs
+
+pathStackDbs :: FilePath -> IO [FilePath]
+pathStackDbs p = readCreateProcess prc "" >>= extractDbs
+  where
+    prc        = (shell cmd) { cwd = Just $ takeDirectory p }
+    cmd        = "stack --verbosity quiet exec printenv GHC_PACKAGE_PATH"
+
+extractDbs :: String -> IO [FilePath]
+extractDbs = filterM doesDirectoryExist . stringPaths
+
+stringPaths :: String -> [String]
+stringPaths = splitBy ':' . trim
+
+splitBy :: Char -> String -> [String]
+splitBy c str
+  | null str' = [x]
+  | otherwise = x : splitBy c (tail str')
+  where
+    (x, str') = span (c /=) str
+
+trim :: String -> String
+trim = f . f
+   where
+     f = reverse . dropWhile isSpace

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -9,13 +9,15 @@ module Types
 import System.Exit (ExitCode)
 
 data CommandExtra = CommandExtra
-  { ceGhcOptions :: [String]
+  { ceGhcOptions  :: [String]
   , ceCabalConfig :: Maybe FilePath
+  , cePath        :: Maybe FilePath
   } deriving (Read, Show)
 
 emptyCommandExtra :: CommandExtra
-emptyCommandExtra = CommandExtra { ceGhcOptions = []
+emptyCommandExtra = CommandExtra { ceGhcOptions  = []
                                  , ceCabalConfig = Nothing
+                                 , cePath        = Nothing
                                  }
 
 data ServerDirective

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+resolver: nightly-2015-07-02


### PR DESCRIPTION
Hi, 

Here's a first cut at adding support for `stack`. The key functions are:
1. `StackConfig` a type that represents information (paths to package databases, dist directories),
2. `getStackConfig` which computes a `StackConfig` _if_ the target file is indeed in a Stack project,
3. `stackifyFlags` which updates the GHC `ConfigFlags` using a `StackConfig`.

It seems to work for both `stack` and old-fashioned non-stack and cabal-sandbox projects, at least for me, modulo the caveats in this thread [1]. Still it would be worthwhile if others (/cc @parsonsmatt) could use/test/improve? 

Thanks!

Ranjit.

[1] https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/haskell-stack/Skfd3QGFzgk/obx7IwPsBqUJ
