### PR TITLE
Fixes for ghc < 7.10

### DIFF
--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -11,6 +11,7 @@ import Control.Monad (when)
 import Data.IORef
 import Data.List (find)
 #if __GLASGOW_HASKELL__ < 709
+import Control.Applicative ((<$>))
 import Data.Traversable (traverse)
 #endif
 import MonadUtils (MonadIO, liftIO)


### PR DESCRIPTION
This branch contains some fixes to compile with ghc < 7.10, but this doesn't solve
the problem reported with https://github.com/schell/hdevtools/issues/11.

