### PR TITLE
Findsymbol command

### DIFF
--- a/hdevtools.cabal
+++ b/hdevtools.cabal
@@ -81,5 +81,7 @@ executable hdevtools
     cpp-options:       -DENABLE_CABAL
 
   if impl(ghc >= 7.9)
-    build-depends:     Cabal >= 1.22
+    build-depends:     Cabal >= 1.22,
+                       bin-package-db
+
     cpp-options:       -DENABLE_CABAL

--- a/src/CommandArgs.hs
+++ b/src/CommandArgs.hs
@@ -80,6 +80,7 @@ data HDevTools
         { socket :: Maybe FilePath
         , ghcOpts :: [String]
         , symbol :: String
+        , file :: String
         }
     deriving (Show, Data, Typeable)
 
@@ -131,6 +132,7 @@ dummyFindSymbol = FindSymbol
     { socket = Nothing
     , ghcOpts = []
     , symbol = ""
+    , file = ""
     }
 
 admin :: Annotate Ann
@@ -181,6 +183,7 @@ findSymbol = record dummyFindSymbol
     [ socket   := def += typFile += help "socket file to use"
     , ghcOpts  := def += typ "OPTION" += help "ghc options"
     , symbol   := def += typ "SYMBOL" += argPos 0
+    , file     := def += typFile += argPos 1
     ] += help "Find the modules where the given symbol is defined"
 
 full :: String -> Annotate Ann

--- a/src/CommandArgs.hs
+++ b/src/CommandArgs.hs
@@ -184,7 +184,7 @@ findSymbol = record dummyFindSymbol
     , ghcOpts  := def += typ "OPTION" += help "ghc options"
     , symbol   := def += typ "SYMBOL" += argPos 0
     , files    := def += typFile += args
-    ] += help "Find the modules where the given symbol is defined"
+    ] += help "List the modules where the given symbol could be found"
 
 full :: String -> Annotate Ann
 full progName = modes_ [admin += auto, check, moduleFile, info, type_, findSymbol]

--- a/src/CommandArgs.hs
+++ b/src/CommandArgs.hs
@@ -76,6 +76,11 @@ data HDevTools
         , line    :: Int
         , col     :: Int
         }
+    | FindSymbol
+        { socket :: Maybe FilePath
+        , ghcOpts :: [String]
+        , symbol :: String
+        }
     deriving (Show, Data, Typeable)
 
 dummyAdmin :: HDevTools
@@ -121,6 +126,13 @@ dummyType = Type
     , col     = 0
     }
 
+dummyFindSymbol :: HDevTools
+dummyFindSymbol = FindSymbol
+    { socket = Nothing
+    , ghcOpts = []
+    , symbol = ""
+    }
+
 admin :: Annotate Ann
 admin = record dummyAdmin
     [ socket       := def += typFile += help "socket file to use"
@@ -164,8 +176,15 @@ type_ = record dummyType
     , col      := def += typ "COLUMN" += argPos 2
     ] += help "Get the type of the expression at the specified line and column"
 
+findSymbol :: Annotate Ann
+findSymbol = record dummyFindSymbol
+    [ socket   := def += typFile += help "socket file to use"
+    , ghcOpts  := def += typ "OPTION" += help "ghc options"
+    , symbol   := def += typ "SYMBOL" += argPos 0
+    ] += help "Find the modules where the given symbol is defined"
+
 full :: String -> Annotate Ann
-full progName = modes_ [admin += auto, check, moduleFile, info, type_]
+full progName = modes_ [admin += auto, check, moduleFile, info, type_, findSymbol]
         += helpArg [name "h", groupname "Help"]
         += versionArg [groupname "Help"]
         += program progName

--- a/src/CommandArgs.hs
+++ b/src/CommandArgs.hs
@@ -80,7 +80,7 @@ data HDevTools
         { socket :: Maybe FilePath
         , ghcOpts :: [String]
         , symbol :: String
-        , file :: String
+        , files :: [String]
         }
     deriving (Show, Data, Typeable)
 
@@ -132,7 +132,7 @@ dummyFindSymbol = FindSymbol
     { socket = Nothing
     , ghcOpts = []
     , symbol = ""
-    , file = ""
+    , files = []
     }
 
 admin :: Annotate Ann
@@ -183,7 +183,7 @@ findSymbol = record dummyFindSymbol
     [ socket   := def += typFile += help "socket file to use"
     , ghcOpts  := def += typ "OPTION" += help "ghc options"
     , symbol   := def += typ "SYMBOL" += argPos 0
-    , file     := def += typFile += argPos 1
+    , files    := def += typFile += args
     ] += help "Find the modules where the given symbol is defined"
 
 full :: String -> Annotate Ann

--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -9,7 +9,7 @@ module CommandLoop
 
 import Control.Monad (when)
 import Data.IORef
-import Data.List (find)
+import Data.List (find, intercalate)
 #if __GLASGOW_HASKELL__ < 709
 import Data.Traversable (traverse)
 #endif
@@ -244,7 +244,7 @@ runCommand state clientSend (CmdFindSymbol symbol files) = do
     where
     formatModules = intercalate "\n"
 
-    
+
 
 #if __GLASGOW_HASKELL__ >= 706
 logAction :: IORef State -> ClientSend -> GHC.DynFlags -> GHC.Severity -> GHC.SrcSpan -> Outputable.PprStyle -> ErrUtils.MsgDoc -> IO ()

--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -230,10 +230,10 @@ runCommand state clientSend (CmdType file (line, col)) = do
             , show endCol , " "
             , "\"", t, "\""
             ]
-runCommand state clientSend (CmdFindSymbol symbol file) = do
+runCommand state clientSend (CmdFindSymbol symbol files) = do
     let noPhase = Nothing
-    target <- GHC.guessTarget file noPhase
-    GHC.setTargets [target]
+    targets <- mapM (flip GHC.guessTarget noPhase) files
+    GHC.setTargets targets
     let handler err = GHC.printException err >> return GHC.Failed
     _ <- GHC.handleSourceError handler (GHC.load GHC.LoadAllTargets)
 

--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -233,7 +233,10 @@ runCommand state clientSend (CmdType file (line, col)) = do
 runCommand state clientSend (CmdFindSymbol symbol) = do
     result <- withWarnings state False $ findSymbol symbol
     case result of
-        []      -> liftIO $ clientSend (ClientExit ExitSuccess)
+        []      -> liftIO $ mapM_ clientSend
+                       [ ClientStderr $ "Couldn't find modules containing '" ++ symbol ++ "'"
+                       , ClientExit (ExitFailure 1)
+                       ]
         modules -> liftIO $ mapM_ clientSend
                        [ ClientStdout (formatModules modules)
                        , ClientExit ExitSuccess

--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -231,11 +231,20 @@ runCommand state clientSend (CmdType file (line, col)) = do
             , "\"", t, "\""
             ]
 runCommand state clientSend (CmdFindSymbol symbol files) = do
+    -- for the findsymbol command GHC shouldn't output any warnings
+    -- or errors to stdout for the loaded source files, we're only
+    -- interested in the module graph of the loaded targets
+    dynFlags <- GHC.getSessionDynFlags
+    _        <- GHC.setSessionDynFlags dynFlags { GHC.log_action = \_ _ _ _ _ -> return () }
+
     let noPhase = Nothing
     targets <- mapM (flip GHC.guessTarget noPhase) files
     GHC.setTargets targets
     let handler err = GHC.printException err >> return GHC.Failed
     _ <- GHC.handleSourceError handler (GHC.load GHC.LoadAllTargets)
+
+    -- reset the old log_action
+    _ <- GHC.setSessionDynFlags dynFlags
 
     result <- withWarnings state False $ findSymbol symbol
     case result of

--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -230,7 +230,13 @@ runCommand state clientSend (CmdType file (line, col)) = do
             , show endCol , " "
             , "\"", t, "\""
             ]
-runCommand state clientSend (CmdFindSymbol symbol) = do
+runCommand state clientSend (CmdFindSymbol symbol file) = do
+    let noPhase = Nothing
+    target <- GHC.guessTarget file noPhase
+    GHC.setTargets [target]
+    let handler err = GHC.printException err >> return GHC.Failed
+    _ <- GHC.handleSourceError handler (GHC.load GHC.LoadAllTargets)
+
     result <- withWarnings state False $ findSymbol symbol
     case result of
         []      -> liftIO $ mapM_ clientSend
@@ -243,6 +249,8 @@ runCommand state clientSend (CmdFindSymbol symbol) = do
                        ]
     where
     formatModules = intercalate "\n"
+
+    
 
 #if __GLASGOW_HASKELL__ >= 706
 logAction :: IORef State -> ClientSend -> GHC.DynFlags -> GHC.Severity -> GHC.SrcSpan -> Outputable.PprStyle -> ErrUtils.MsgDoc -> IO ()

--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -231,22 +231,7 @@ runCommand state clientSend (CmdType file (line, col)) = do
             , "\"", t, "\""
             ]
 runCommand state clientSend (CmdFindSymbol symbol files) = do
-    -- for the findsymbol command GHC shouldn't output any warnings
-    -- or errors to stdout for the loaded source files, we're only
-    -- interested in the module graph of the loaded targets
-    dynFlags <- GHC.getSessionDynFlags
-    _        <- GHC.setSessionDynFlags dynFlags { GHC.log_action = \_ _ _ _ _ -> return () }
-
-    let noPhase = Nothing
-    targets <- mapM (flip GHC.guessTarget noPhase) files
-    GHC.setTargets targets
-    let handler err = GHC.printException err >> return GHC.Failed
-    _ <- GHC.handleSourceError handler (GHC.load GHC.LoadAllTargets)
-
-    -- reset the old log_action
-    _ <- GHC.setSessionDynFlags dynFlags
-
-    result <- withWarnings state False $ findSymbol symbol
+    result <- withWarnings state False $ findSymbol symbol files
     case result of
         []      -> liftIO $ mapM_ clientSend
                        [ ClientStderr $ "Couldn't find modules containing '" ++ symbol ++ "'"

--- a/src/FindSymbol.hs
+++ b/src/FindSymbol.hs
@@ -5,50 +5,75 @@ module FindSymbol
     ) where
 
 import Control.Applicative ((<$>))
-import Control.Monad (foldM)
+import Control.Monad (filterM)
 import Control.Exception
 import Data.List (find, nub)
-import Data.Maybe (catMaybes)
+import Data.Maybe (catMaybes, isJust)
 import qualified GHC                    
 import qualified UniqFM
 import qualified Packages as PKG
 import qualified Name
 import Exception (ghandle)
 
-findSymbol :: String -> GHC.Ghc [String]
-findSymbol symbol = do
-   graphModules <- modulesWith symbol =<< allModulesFromGraph
-   expModules   <- modulesWith symbol =<< allExposedModules
-   return . nub $ graphModules ++ expModules
+type SymbolName = String
+type ModuleName = String
+
+findSymbol :: SymbolName -> [FilePath] -> GHC.Ghc [ModuleName]
+findSymbol symbol files = do
+   -- for the findsymbol command GHC shouldn't output any warnings
+   -- or errors to stdout for the loaded source files, we're only
+   -- interested in the module graph of the loaded targets
+   dynFlags <- GHC.getSessionDynFlags
+   _        <- GHC.setSessionDynFlags dynFlags { GHC.log_action = \_ _ _ _ _ -> return () }
+
+   fileMods <- concat <$> mapM (findSymbolInFile symbol) files
+
+   -- reset the old log_action
+   _ <- GHC.setSessionDynFlags dynFlags
+
+   pkgsMods <- findSymbolInPackages symbol
+   return . nub . map (GHC.moduleNameString . GHC.moduleName) $ fileMods ++ pkgsMods
+
+
+findSymbolInFile :: SymbolName -> FilePath -> GHC.Ghc [GHC.Module]
+findSymbolInFile symbol file = do
+   loadFile
+   filterM (containsSymbol symbol) =<< fileModules
    where
-   modulesWith sym = foldM (hasSym sym) []
+   loadFile = do
+      let noPhase = Nothing
+      target <- GHC.guessTarget file noPhase
+      GHC.setTargets [target]
+      let handler err = GHC.printException err >> return GHC.Failed
+      _ <- GHC.handleSourceError handler (GHC.load GHC.LoadAllTargets)
+      return ()
 
-   hasSym sym modsWithSym modul = do
-      syms <- allExportedSymbols modul
-      return $ case find (== sym) syms of
-                   Just _ -> (GHC.moduleNameString . GHC.moduleName $ modul) : modsWithSym
-                   _      -> modsWithSym
+   fileModules = map GHC.ms_mod <$> GHC.getModuleGraph
 
-allExportedSymbols :: GHC.Module -> GHC.Ghc [String]
-allExportedSymbols module_ =
-   ghandle (\(_ :: SomeException) -> return [])
-           (do info <- GHC.getModuleInfo module_
-               return $ maybe [] (map Name.getOccString . GHC.modInfoExports) info)
 
-allModulesFromGraph :: GHC.Ghc [GHC.Module]
-allModulesFromGraph = do
-    moduleGraph <- GHC.getModuleGraph
-    return $ map GHC.ms_mod moduleGraph
-
-allExposedModules :: GHC.Ghc [GHC.Module]
-allExposedModules = do
-   modNames <- exposedModuleNames <$> GHC.getSessionDynFlags
-   catMaybes <$> mapM findModule modNames
+findSymbolInPackages :: SymbolName -> GHC.Ghc [GHC.Module]
+findSymbolInPackages symbol =
+   filterM (containsSymbol symbol) =<< allExposedModules
    where
-   exposedModuleNames = concatMap (\pkg -> if PKG.exposed pkg then PKG.exposedModules pkg else [])
-                        . UniqFM.eltsUFM . PKG.pkgIdMap . GHC.pkgState
+   allExposedModules :: GHC.Ghc [GHC.Module]
+   allExposedModules = do
+      modNames <- exposedModuleNames <$> GHC.getSessionDynFlags
+      catMaybes <$> mapM findModule modNames
+      where
+      exposedModuleNames = concatMap (\pkg -> if PKG.exposed pkg then PKG.exposedModules pkg else [])
+                           . UniqFM.eltsUFM . PKG.pkgIdMap . GHC.pkgState
 
-findModule :: GHC.ModuleName -> GHC.Ghc (Maybe GHC.Module)
-findModule moduleName =
-   ghandle (\(_ :: SomeException) -> return Nothing)
-           (Just <$> GHC.findModule moduleName Nothing)
+      findModule :: GHC.ModuleName -> GHC.Ghc (Maybe GHC.Module)
+      findModule moduleName =
+         ghandle (\(_ :: SomeException) -> return Nothing)
+                 (Just <$> GHC.findModule moduleName Nothing)
+
+
+containsSymbol :: SymbolName -> GHC.Module -> GHC.Ghc Bool
+containsSymbol symbol module_ =
+   isJust . find (== symbol) <$> allExportedSymbols
+   where
+   allExportedSymbols =
+      ghandle (\(_ :: SomeException) -> return [])
+              (do info <- GHC.getModuleInfo module_
+                  return $ maybe [] (map Name.getOccString . GHC.modInfoExports) info)

--- a/src/FindSymbol.hs
+++ b/src/FindSymbol.hs
@@ -7,7 +7,7 @@ module FindSymbol
 import Control.Applicative ((<$>))
 import Control.Monad (foldM)
 import Control.Exception
-import Data.List (find)
+import Data.List (find, nub)
 import Data.Maybe (catMaybes)
 import qualified GHC                    
 import qualified UniqFM
@@ -19,7 +19,7 @@ findSymbol :: String -> GHC.Ghc [String]
 findSymbol symbol = do
    graphModules <- modulesWith symbol =<< allModulesFromGraph
    expModules   <- modulesWith symbol =<< allExposedModules
-   return $ graphModules ++ expModules
+   return . nub $ graphModules ++ expModules
    where
    modulesWith sym = foldM (hasSym sym) []
 

--- a/src/FindSymbol.hs
+++ b/src/FindSymbol.hs
@@ -1,0 +1,40 @@
+module FindSymbol
+    ( findSymbol
+    ) where
+
+import Control.Applicative ((<$>))
+import Control.Monad (foldM)
+import Data.List (find)
+import qualified GHC                    
+import qualified UniqFM
+import qualified Packages as PKG
+import qualified Name
+
+findSymbol :: String -> GHC.Ghc [String]
+findSymbol symbol = do
+   modules <- allExposedModules
+   modulesWith symbol modules
+   where
+   modulesWith sym = foldM (hasSym sym) []
+
+   hasSym sym modsWithSym modul = do
+      syms <- allExportedSymbols modul
+      return $ case find (== sym) syms of
+                   Just _ -> (GHC.moduleNameString modul) : modsWithSym
+                   _      -> modsWithSym
+
+allExportedSymbols :: GHC.ModuleName -> GHC.Ghc [String]
+allExportedSymbols modul = do
+   maybeInfo <- moduleInfo
+   case maybeInfo of
+       Just info -> return $ exports info
+       _         -> return []
+   where
+   exports    = map Name.getOccString . GHC.modInfoExports
+   moduleInfo = GHC.findModule modul Nothing >>= GHC.getModuleInfo
+
+allExposedModules :: GHC.Ghc [GHC.ModuleName]
+allExposedModules = getExposedModules <$> GHC.getSessionDynFlags
+   where
+   getExposedModules = concatMap (\pkg -> if PKG.exposed pkg then PKG.exposedModules pkg else [])
+                       . UniqFM.eltsUFM . PKG.pkgIdMap . GHC.pkgState

--- a/src/FindSymbol.hs
+++ b/src/FindSymbol.hs
@@ -1,16 +1,22 @@
-{-# Language ScopedTypeVariables #-}
+{-# Language ScopedTypeVariables, CPP #-}
 
 module FindSymbol
     ( findSymbol
     ) where
 
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative ((<$>))
+import qualified UniqFM
+#else
+import GHC.PackageDb (exposedName)
+import GhcMonad (liftIO)
+#endif
+
 import Control.Monad (filterM)
 import Control.Exception
 import Data.List (find, nub)
 import Data.Maybe (catMaybes, isJust)
-import qualified GHC                    
-import qualified UniqFM
+import qualified GHC
 import qualified Packages as PKG
 import qualified Name
 import Exception (ghandle)
@@ -57,11 +63,25 @@ findSymbolInPackages symbol =
    where
    allExposedModules :: GHC.Ghc [GHC.Module]
    allExposedModules = do
-      modNames <- exposedModuleNames <$> GHC.getSessionDynFlags
+      modNames <- exposedModuleNames
       catMaybes <$> mapM findModule modNames
       where
-      exposedModuleNames = concatMap (\pkg -> if PKG.exposed pkg then PKG.exposedModules pkg else [])
-                           . UniqFM.eltsUFM . PKG.pkgIdMap . GHC.pkgState
+      exposedModuleNames :: GHC.Ghc [GHC.ModuleName]
+#if __GLASGOW_HASKELL__ < 710
+      exposedModuleNames =
+         concatMap exposedModules
+                   . UniqFM.eltsUFM
+		   . PKG.pkgIdMap
+		   . GHC.pkgState
+		   <$> GHC.getSessionDynFlags
+#else
+      exposedModuleNames = do
+	 dynFlags <- GHC.getSessionDynFlags
+	 pkgConfigs <- liftIO $ PKG.readPackageConfigs dynFlags
+	 return $ map exposedName (concatMap exposedModules pkgConfigs)
+#endif
+
+      exposedModules pkg = if PKG.exposed pkg then PKG.exposedModules pkg else []
 
       findModule :: GHC.ModuleName -> GHC.Ghc (Maybe GHC.Module)
       findModule moduleName =

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -35,6 +35,7 @@ fileArg (ModuleFile {}) = Nothing
 fileArg args@(Check {}) = Just $ file args
 fileArg args@(Info  {}) = Just $ file args
 fileArg args@(Type  {}) = Just $ file args
+fileArg (FindSymbol {}) = Nothing
 
 pathArg' :: HDevTools -> Maybe String
 pathArg' (Admin {})      = Nothing
@@ -42,6 +43,7 @@ pathArg' (ModuleFile {}) = Nothing
 pathArg' args@(Check {}) = path args
 pathArg' args@(Info  {}) = path args
 pathArg' args@(Type  {}) = path args
+pathArg' (FindSymbol {}) = Nothing
 
 pathArg :: HDevTools -> Maybe String
 pathArg args = case pathArg' args of
@@ -67,6 +69,7 @@ main = do
         ModuleFile {} -> doModuleFile sock args extra
         Info {} -> doInfo sock args extra
         Type {} -> doType sock args extra
+        FindSymbol {} -> doFindSymbol sock args extra
 
 doAdmin :: FilePath -> HDevTools -> CommandExtra -> IO ()
 doAdmin sock args _extra
@@ -108,3 +111,7 @@ doInfo = doFileCommand "info" $
 doType :: FilePath -> HDevTools -> CommandExtra -> IO ()
 doType = doFileCommand "type" $
     \args -> CmdType (file args) (line args, col args)
+
+doFindSymbol :: FilePath -> HDevTools -> CommandExtra -> IO ()
+doFindSymbol sock args extra =
+    serverCommand sock (CmdFindSymbol (symbol args) (files args)) extra

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -38,5 +38,5 @@ data Command
     | CmdModuleFile String
     | CmdInfo FilePath String
     | CmdType FilePath (Int, Int)
-    | CmdFindSymbol String String
+    | CmdFindSymbol String [String]
     deriving (Read, Show)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -38,5 +38,5 @@ data Command
     | CmdModuleFile String
     | CmdInfo FilePath String
     | CmdType FilePath (Int, Int)
-    | CmdFindSymbol String
+    | CmdFindSymbol String String
     deriving (Read, Show)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -38,4 +38,5 @@ data Command
     | CmdModuleFile String
     | CmdInfo FilePath String
     | CmdType FilePath (Int, Int)
+    | CmdFindSymbol String
     deriving (Read, Show)


### PR DESCRIPTION
For quite some time I'm now maintaining this branch of `hdevtools` which adds
a `findsymbol` command which is the basis of https://github.com/dan-t/vim-hsimport.

The command lists all modules where the given symbol could be found which is the
base information for extending the imports in a Haskell source file.

Is there any chance to get this merged?


Greetings,
Daniel