### PR TITLE
Fix compiling of test/benchmark section files

### DIFF
--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -129,6 +129,12 @@ getPackageGhcOpts path mbStack opts = do
                              { configDistPref = toFlag distDir
                              -- TODO: figure out how to find out this flag
                              , configUserInstall = toFlag True
+
+                             -- configure with --enable-tests to include test dependencies/modules
+                             , configTests = toFlag True
+
+                             -- configure with --enable-benchmarks to include benchmark dependencies/modules
+                             , configBenchmarks = toFlag True
                              }
         let initCfgFlags' = stackifyFlags initCfgFlags mbStack
 


### PR DESCRIPTION
This ensures that the dependencies of the test and benchmark sections
are considered and therefore files from these sections can be compiled.